### PR TITLE
remove BOM

### DIFF
--- a/Src/Sunra/PhpSimple/HtmlDomParser.php
+++ b/Src/Sunra/PhpSimple/HtmlDomParser.php
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 namespace Sunra\PhpSimple;
 
 


### PR DESCRIPTION
BOM prevents proper header sending etc. and also throws the following error

> PHP Fatal error:  Namespace declaration statement has to be the very first statement in the script in /Volumes/Data/Web/airbank_api/vendor/sunra/php-simple-html-dom-parser/Src/Sunra/PhpSimple/HtmlDomParser.php on line 2
