### PR TITLE
convert_text() is now called on TEXT nodes (Fixes #6)

### DIFF
--- a/Src/Sunra/PhpSimple/simplehtmldom_1_5/simple_html_dom.php
+++ b/Src/Sunra/PhpSimple/simplehtmldom_1_5/simple_html_dom.php
@@ -384,7 +384,7 @@ class simple_html_dom_node
             call_user_func_array($this->dom->callback, array($this));
         }
 
-        if (isset($this->_[HDOM_INFO_OUTER])) return $this->convert_tetxt($this->_[HDOM_INFO_OUTER]);
+        if (isset($this->_[HDOM_INFO_OUTER])) return $this->convert_text($this->_[HDOM_INFO_OUTER]);
         if (isset($this->_[HDOM_INFO_TEXT])) return $this->convert_text($this->dom->restore_noise($this->_[HDOM_INFO_TEXT]));
 
         // render begin tag


### PR DESCRIPTION
When outerText() get a TEXT node it will convert the text using the
convert_text() method to ensure it is utf-8 complient.
(fixes #6)
