### PR TITLE
add PHPDoc for $children

### DIFF
--- a/Src/Sunra/PhpSimple/simplehtmldom_1_5/simple_html_dom.php
+++ b/Src/Sunra/PhpSimple/simplehtmldom_1_5/simple_html_dom.php
@@ -116,6 +116,7 @@ class simple_html_dom_node
     public $nodetype = HDOM_TYPE_TEXT;
     public $tag = 'text';
     public $attr = array();
+    /** @var simple_html_dom_node[] $children */
     public $children = array();
     public $nodes = array();
     public $parent = null;


### PR DESCRIPTION
So that PhpStorm will understand that plaintext is a valid property of children(1) in ```$something->children(1)->plaintext;```