### PR TITLE
Exclude development stuff from repository autogenerated ZIP archives

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+/.* export-ignore
+/Src/Sunra/PhpSimple/simplehtmldom_1_5/app export-ignore
+/Src/Sunra/PhpSimple/simplehtmldom_1_5/example export-ignore
+/Src/Sunra/PhpSimple/simplehtmldom_1_5/manual export-ignore
+/Src/Sunra/PhpSimple/simplehtmldom_1_5/testcase export-ignore


### PR DESCRIPTION
People that install this library via composer don't need the test/sample/doc stuff, they just need the library itself.
This PR removes the development directories and files from the repository auto-generated ZIP archives.
Since these development files/directories will still be available via `git clone`, developers are happy, and so are end-users (they won't have unneeded stuff in production machines).