### PR TITLE
Replace text encoding function

### DIFF
--- a/Src/Sunra/PhpSimple/simplehtmldom_1_5/simple_html_dom.php
+++ b/Src/Sunra/PhpSimple/simplehtmldom_1_5/simple_html_dom.php
@@ -800,7 +800,7 @@ class simple_html_dom_node
             }
             else
             {
-                $converted_text = iconv($sourceCharset, $targetCharset, $text);
+                $converted_text = mb_convert_encoding($text, $targetCharset, $sourceCharset);
             }
         }
 


### PR DESCRIPTION
Changed encoding function in convert_text. There was iconv, but now is
mb_convert_encoding. It needs, because when we pass HTML in UTF-8
during creating instance of simple_html_dom and target character set
windows-1251 and want to get some text through ->text() sometimes we
catch an error "iconv(): Detected an illegal character in input string".