### PR TITLE
Escape minus char in regular expressions

### DIFF
--- a/Src/Sunra/PhpSimple/simplehtmldom_1_5/simple_html_dom.php
+++ b/Src/Sunra/PhpSimple/simplehtmldom_1_5/simple_html_dom.php
@@ -692,8 +692,8 @@ class simple_html_dom_node
 // Notice the \[ starting the attbute?  and the @? following?  This implies that an attribute can begin with an @ sign that is not captured.
 // This implies that an html attribute specifier may start with an @ sign that is NOT captured by the expression.
 // farther study is required to determine of this should be documented or removed.
-//        $pattern = "/([\w-:\*]*)(?:\#([\w-]+)|\.([\w-]+))?(?:\[@?(!?[\w-]+)(?:([!*^$]?=)[\"']?(.*?)[\"']?)?\])?([\/, ]+)/is";
-        $pattern = "/([\w-:\*]*)(?:\#([\w-]+)|\.([\w-]+))?(?:\[@?(!?[\w-:]+)(?:([!*^$]?=)[\"']?(.*?)[\"']?)?\])?([\/, ]+)/is";
+//        $pattern = "/([\w\-:\*]*)(?:\#([\w\-]+)|\.([\w\-]+))?(?:\[@?(!?[\w\-]+)(?:([!*^$]?=)[\"']?(.*?)[\"']?)?\])?([\/, ]+)/is";
+        $pattern = "/([\w\-:\*]*)(?:\#([\w\-]+)|\.([\w\-]+))?(?:\[@?(!?[\w\-:]+)(?:([!*^$]?=)[\"']?(.*?)[\"']?)?\])?([\/, ]+)/is";
         preg_match_all($pattern, trim($selector_string).' ', $matches, PREG_SET_ORDER);
         if (is_object($debugObject)) {$debugObject->debugLog(2, "Matches Array: ", $matches);}
 
@@ -899,7 +899,7 @@ class simple_html_dom_node
         {
             // Thanks to user gnarf from stackoverflow for this regular expression.
             $attributes = array();
-            preg_match_all("/([\w-]+)\s*:\s*([^;]+)\s*;?/", $this->attr['style'], $matches, PREG_SET_ORDER);
+            preg_match_all("/([\w\-]+)\s*:\s*([^;]+)\s*;?/", $this->attr['style'], $matches, PREG_SET_ORDER);
             foreach ($matches as $match) {
               $attributes[$match[1]] = $match[2];
             }
@@ -1375,7 +1375,7 @@ class simple_html_dom
             return true;
         }
 
-        if (!preg_match("/^[\w-:]+$/", $tag)) {
+        if (!preg_match("/^[\w\-:]+$/", $tag)) {
             $node->_[HDOM_INFO_TEXT] = '<' . $tag . $this->copy_until('<>');
             if ($this->char==='<') {
                 $this->link_nodes($node, false);


### PR DESCRIPTION
In PHP 7.3, PCRE2 (the library that parses regular expressions) has been upgraded to version 10.32.

It seems that this new version of PCRE is a bit more picky when parsing regular expressions.
For example, `/^[\w-:]+$` is not accepted anymore, we have this error (see https://3v4l.org/vD5O2):
```
Compilation failed: invalid range in character class at offset 4
```
The reason? `-` is used to represent range of characters when in square brackets (for example: `[A-Z]` represents a character from `A` to `Z`).
And PCRE now interprets `[\w-:]` as `any character from \w to :`, which doesn't make sense (so the error is thrown).

The solution? Just escape `-` with `\` to tell PCRE that we actually want the character `-`, and not a range of characters.